### PR TITLE
Add RBAC - Route protection with @requires_roles and token role checks

### DIFF
--- a/app/controllers/users.py
+++ b/app/controllers/users.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, request, jsonify
+from app.utils.auth import requires_roles
 from app.services.user_service import UserService
 from app.utils.auth import token_required
 
@@ -74,4 +75,18 @@ def protected_route():
     return jsonify({
         "message": "Access granted!",
         "user_id": request.user_id
+    }), 200
+
+
+@users_bp.route("/guild-leader-only", methods=["GET"])
+@token_required
+@requires_roles("guild_leader")
+def guild_leader_only():
+    """
+    Only accessible by users with the 'guild_leader' role.
+    """
+    return jsonify({
+        "message": "Welcome Guild Leader!",
+        "user_id": request.user_id,
+        "role": request.user_role
     }), 200

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -28,7 +28,7 @@ class UserService:
         if not user or not verify_password(user.password, password):
             raise ValueError("Invalid email or password")
 
-        token = generate_token(user.id)
+        token = generate_token(user.id, user.role.value)
         return user, token
 
     @staticmethod

--- a/app/utils/auth.py
+++ b/app/utils/auth.py
@@ -20,9 +20,10 @@ def token_required(f):
             if not secret:
                 return jsonify({"error": "Server configuration issue"}), 500
 
-            # Decode token and attach user_id to the request context
+            # Decode token and attach user_id and role to the request context
             decoded = jwt.decode(token, secret, algorithms=["HS256"])
             request.user_id = decoded["sub"]
+            request.user_role = decoded.get("role")
         except jwt.ExpiredSignatureError:
             return jsonify({"error": "Token expired"}), 401
         except jwt.InvalidTokenError:
@@ -30,3 +31,19 @@ def token_required(f):
 
         return f(*args, **kwargs)
     return decorated
+
+def requires_roles(*roles):
+    def decorator(f):
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            # Check if user_id and role are set by token_required
+            if not hasattr(request, "user_id") or not hasattr(request, "user_role"):
+                return jsonify({"error": "Missing authentication context"}), 403
+
+            # Reject if user doesn't have one of the allowed roles
+            if request.user_role not in roles:
+                return jsonify({"error": "Forbidden: Insufficient role"}), 403
+
+            return f(*args, **kwargs)
+        return wrapper
+    return decorator

--- a/app/utils/security.py
+++ b/app/utils/security.py
@@ -3,11 +3,13 @@ from werkzeug.security import generate_password_hash, check_password_hash
 import jwt
 from os import getenv
 
+
 def hash_password(password: str) -> str:
     """
     Hashes a plain text password using Werkzeug.
     """
     return generate_password_hash(password)
+
 
 def verify_password(stored_hash: str, plain_password: str) -> bool:
     """
@@ -15,18 +17,20 @@ def verify_password(stored_hash: str, plain_password: str) -> bool:
     """
     return check_password_hash(stored_hash, plain_password)
 
-def generate_token(user_id: int) -> str:
+
+def generate_token(user_id: int, role: str) -> str:
     """
-    Generates a JWT token with user ID and 1 hour expiration.
+    Generates a JWT token with user ID and role, valid for 1 hour.
     """
     payload = {
-        "sub": str(user_id),  # subject must be a string
+        "sub": str(user_id),
+        "role": role,
         "exp": datetime.now(timezone.utc) + timedelta(hours=1)
     }
     secret = getenv("SECRET_KEY")
     token = jwt.encode(payload, secret, algorithm="HS256")
 
-    # Ensure token is a string, not bytes
+    # Ensure token is string (in case bytes are returned)
     if isinstance(token, bytes):
         token = token.decode("utf-8")
 


### PR DESCRIPTION
- Implemented @requires_roles decorator to restrict access based on user roles.

- Enhanced @token_required to decode and attach both user_id and user_role.
 
- Added /guild-leader-only route that allows access only to users with the guild_leader role.
 
- Updated JWT generation to include the user's role in the payload.