### PR TITLE
Add guild leave functionality and tests for members and leaders

### DIFF
--- a/app/controllers/guilds.py
+++ b/app/controllers/guilds.py
@@ -104,3 +104,17 @@ def update_guild(guild_id):
 
     except ValueError as ve:
         return jsonify({"error": str(ve)}), 400
+
+
+@guilds_bp.route("/guilds/<int:guild_id>/leave", methods=["DELETE"])
+@token_required  # Ensure the user is authenticated
+def leave_guild(guild_id):
+    """
+    Allows a logged-in user to leave their current guild.
+    Guild leaders are not allowed to leave unless they transfer leadership (not yet implemented).
+    """
+    try:
+        GuildService.leave_guild(user_id=request.user_id, guild_id=guild_id)
+        return jsonify({"message": "You have successfully left the guild."}), 200
+    except ValueError as ve:
+        return jsonify({"error": str(ve)}), 400

--- a/app/services/guild_service.py
+++ b/app/services/guild_service.py
@@ -89,3 +89,23 @@ class GuildService:
         db.session.commit()
 
         return guild
+
+    @staticmethod
+    def leave_guild(user_id: int, guild_id: int) -> None:
+        """
+        Allows a user to leave a guild, unless they are the guild leader.
+        """
+        user = db.session.get(User, user_id)
+        if not user:
+            raise ValueError("User not found")
+
+        if user.guild_id != guild_id:
+            raise ValueError("You are not a member of this guild")
+
+        if user.role == RoleEnum.guild_leader:
+            raise ValueError(
+                "Guild leaders must transfer leadership before leaving.")
+
+        # Remove user from the guild
+        user.guild_id = None
+        db.session.commit()


### PR DESCRIPTION
*Summary
This update lets users leave a guild using a DELETE request to `/guilds/<guild_id>/leave`.

*What was added
- Regular members can leave a guild.
- Guild leaders are not allowed to leave unless they transfer leadership (we'll add that in the future).
- Error messages show up if someone tries to leave a guild they aren’t in, or if a guild leader tries to leave.
- Two new tests were added:
  - One test for a regular member leaving a guild
  - One test to make sure guild leaders can’t leave