### PR TITLE
feat: add support for guild leadership transfer and related tests

### DIFF
--- a/app/controllers/guilds.py
+++ b/app/controllers/guilds.py
@@ -118,3 +118,33 @@ def leave_guild(guild_id):
         return jsonify({"message": "You have successfully left the guild."}), 200
     except ValueError as ve:
         return jsonify({"error": str(ve)}), 400
+
+
+@guilds_bp.route("/guilds/<int:guild_id>/transfer-leadership", methods=["POST"])
+@token_required  # Only authenticated users can perform this action
+def transfer_guild_leadership(guild_id):
+    """
+    Allows the current guild leader to transfer leadership to another member of the guild.
+    Expects 'new_leader_id' in the JSON payload.
+    """
+    data = request.get_json() or {}
+    try:
+        new_leader_id = int(data.get("new_leader_id"))
+    except (TypeError, ValueError):
+        return jsonify({"error": "New leader ID must be a valid integer"}), 400
+
+    if not new_leader_id:
+        return jsonify({"error": "New leader ID is required"}), 400
+
+    try:
+        # Attempt the leadership transfer via the service layer
+        GuildService.transfer_leadership(
+            guild_id=guild_id,
+            current_leader_id=request.user_id,
+            new_leader_id=new_leader_id
+        )
+
+        return jsonify({"message": "Guild leadership has been successfully transferred."}), 200
+
+    except ValueError as ve:
+        return jsonify({"error": str(ve)}), 400

--- a/app/services/guild_service.py
+++ b/app/services/guild_service.py
@@ -109,3 +109,35 @@ class GuildService:
         # Remove user from the guild
         user.guild_id = None
         db.session.commit()
+
+    @staticmethod
+    def transfer_leadership(guild_id: int, current_leader_id: int, new_leader_id: int) -> None:
+        """
+        Transfers leadership of a guild from the current leader to another member.
+        """
+        guild = db.session.get(Guild, guild_id)
+        if not guild:
+            raise ValueError("Guild not found")
+
+        # Ensure the requester is the current leader
+        current_leader = db.session.get(User, current_leader_id)
+        if not current_leader or current_leader.role != RoleEnum.guild_leader:
+            raise ValueError(
+                "Only the current guild leader can transfer leadership")
+
+        if current_leader.guild_id != guild_id:
+            raise ValueError("You are not the leader of this guild")
+
+        # Ensure the new leader exists and is in the same guild
+        new_leader = db.session.get(User, new_leader_id)
+        if not new_leader or new_leader.guild_id != guild_id:
+            raise ValueError("New leader must be a member of the same guild")
+
+        # Update roles
+        current_leader.role = RoleEnum.member
+        new_leader.role = RoleEnum.guild_leader
+
+        # Update the guild's created_by field to reflect the new leader
+        guild.created_by = new_leader_id
+
+        db.session.commit()


### PR DESCRIPTION
*What’s New
    New API Endpoint
    POST /api/v1/guilds/<guild_id>/transfer-leadership
    This lets the current guild leader choose someone else in the same guild to become the new leader.

*What it does

    The current leader becomes a regular member.
    
    The selected user becomes the new guild leader.
    
    The guild’s created_by is updated to the new leader.

*Rules

    Only the current leader can do this.
    
    The new leader must already be a member of the same guild.

*Tests Added
    Confirm that leadership transfer works correctly.
    
    Confirm that transfer fails if the chosen user is not in the same guild.